### PR TITLE
Bugfix: revised command timeouts

### DIFF
--- a/docs/Chat/Configuration.md
+++ b/docs/Chat/Configuration.md
@@ -8,6 +8,7 @@ Each and every option listed below is optional. Running TwitchJS without options
 
 * `clientId`: _String_ - Used to identify your [application](https://dev.twitch.tv/dashboard/apps) to the API (Default: `null`)
 * `debug`: _Boolean_ - Show debug messages in console (Default: `false`)
+* `commandTimeout`: _Integer_ - Number of ms before command will timeout if no response from server (Default: `600`)
 
 `connection`: (_Optional_)
 

--- a/src/client.js
+++ b/src/client.js
@@ -1482,13 +1482,10 @@ client.prototype._onClose = function _onClose() {
   this.ws = null;
 };
 
-// Minimum of 600ms for command promises, if current latency exceeds, add 100ms
-// to it to make sure it doesn't get timed out..
+// Promise delay for commands will fluctuate with the current server latency to
+// make sure it doesn't time out prematurely
 client.prototype._getPromiseDelay = function _getPromiseDelay() {
-  if (this.currentLatency <= 600) {
-    return 600;
-  }
-  return this.currentLatency + 100;
+  return this.currentLatency + _.get(this.opts.options.commandTimeout, 600);
 };
 
 // Send command to server or channel..


### PR DESCRIPTION
## Proposed changes

Changes how Promise delay timeouts are calculated.
Allows the default Promise delay for commands to be user configurable.
Fixes problem described here: https://github.com/twitch-apis/twitch-js/issues/111

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)

## Checklist

* [x] I have read the [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] My PR is named according to [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] Lint and unit tests pass locally with my changes
* ~~I have added tests that prove my fix is effective or that my feature works~~
* [x] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Further comments

This is my first attempt at a pull request. Let me know if I'm doing anything wrong.

A default of 600ms really means that the Promise will race for 600ms _in addition_ to the current server latency.

Resolves #111 