### PR TITLE
Bugfix: fallback to `setTimeout` if `setImmediate` is not defined

### DIFF
--- a/src/Chat/Queue.js
+++ b/src/Chat/Queue.js
@@ -2,6 +2,7 @@ import BetterQueue from 'better-queue'
 import MemoryStore from 'better-queue-memory'
 
 import * as constants from './constants'
+import { defer } from './utils'
 
 class Queue extends BetterQueue {
   rateLimiter = 0
@@ -17,10 +18,7 @@ class Queue extends BetterQueue {
       {
         store: new MemoryStore(),
         priority: ({ priority = 1 }, cb) => cb(null, priority),
-        setImmediate:
-          typeof setImmediate !== 'undefined'
-            ? setImmediate
-            : cb => setTimeout(cb, 0),
+        setImmediate: defer,
         // Process queue only when rate-limiter is less than 1.
         precondition: cb => cb(null, this.rateLimiter < 1),
         preconditionRetryTimeout: constants.QUEUE_TICK_RATE,

--- a/src/Chat/Queue.js
+++ b/src/Chat/Queue.js
@@ -17,6 +17,10 @@ class Queue extends BetterQueue {
       {
         store: new MemoryStore(),
         priority: ({ priority = 1 }, cb) => cb(null, priority),
+        setImmediate:
+          typeof setImmediate !== 'undefined'
+            ? setImmediate
+            : cb => setTimeout(cb, 0),
         // Process queue only when rate-limiter is less than 1.
         precondition: cb => cb(null, this.rateLimiter < 1),
         preconditionRetryTimeout: constants.QUEUE_TICK_RATE,

--- a/src/Chat/utils/__tests__/index.test.js
+++ b/src/Chat/utils/__tests__/index.test.js
@@ -1,0 +1,31 @@
+import * as utils from '../index'
+
+describe('defer', () => {
+  const realSetImmediate = self.setImmediate
+
+  beforeEach(() => {
+    self.setImmediate = realSetImmediate
+  })
+
+  afterAll(() => {
+    self.setImmediate = realSetImmediate
+  })
+
+  test('should execute when setImmediate is defined', async () => {
+    const promise = new Promise(resolve => {
+      utils.defer(resolve)
+    })
+
+    await expect(promise).resolves.toBeUndefined()
+  })
+
+  test('should execute when setImmediate is undefined', async () => {
+    self.setImmediate = undefined
+
+    const promise = new Promise(resolve => {
+      utils.defer(resolve)
+    })
+
+    await expect(promise).resolves.toBeUndefined()
+  })
+})

--- a/src/Chat/utils/index.js
+++ b/src/Chat/utils/index.js
@@ -15,4 +15,12 @@ const getMessageQueueWeight = ({
   return constants.RATE_LIMIT_USER
 }
 
-export { getMessageQueueWeight }
+const defer = cb => {
+  if (typeof self.setImmediate !== 'undefined') {
+    return self.setImmediate(cb)
+  }
+
+  return self.setTimeout(cb, 0)
+}
+
+export { getMessageQueueWeight, defer }


### PR DESCRIPTION
## Proposed changes

This change could be useful when `twitch-js` is used by another Webpack module which doesn't implement `setImmediate`.

## Types of changes

What types of changes does your code introduce to TwitchJS?
_Put an `x` in the boxes that apply and remove those that do not apply_

* [x] Chore (change that does not fix an issue or add functionality, but improves TwitchJS in some other way)

## Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your code._

* [x] I have read the [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] My PR is named according to [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Further comments

When implementing the new `twitch-js` library in my browser client, the `setImmediate` error happened, causing various issues. With this fix, either people wanting to build an application from transpiled sources for web, node or other targets can do it without effort.