### PR TITLE
Bugfix: fix currentLatency calculation

### DIFF
--- a/src/client.js
+++ b/src/client.js
@@ -132,7 +132,7 @@ client.prototype.handleMessage = function handleMessage(message) {
         case 'PONG': {
           const currDate = new Date();
           this.currentLatency =
-            (currDate.getTime() - this.latency.getTime()) / 1000;
+            currDate.getTime() - this.latency.getTime();
           this.emits(
             ['pong', '_promisePing'],
             [[this.currentLatency], [this.currentLatency]],


### PR DESCRIPTION
## Proposed changes

Correct how `currentLatency` is calculated.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

* [x] I have read the [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] My PR is named according to [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] Lint and unit tests pass locally with my changes
* [ ] ~~I have added tests that prove my fix is effective or that my feature works~~
* [ ] ~~I have added necessary documentation (if appropriate)~~
* [ ] ~~Any dependent changes have been merged and published in downstream modules~~

## Further comments

When the latency was 1 second, the old calc was setting `currentLatency` to `1` instead of `1000`.
