### PR TITLE
Feature: anonymous login

### DIFF
--- a/__mocks__/ws/__fixtures__/commands.json
+++ b/__mocks__/ws/__fixtures__/commands.json
@@ -1,4 +1,5 @@
 {
+  "WELCOME": ":tmi.twitch.tv 001 <user> :Welcome, GLHF!\n:tmi.twitch.tv 002 <user> :Your host is tmi.twitch.tv\n:tmi.twitch.tv 003 <user> :This server is rather new\n:tmi.twitch.tv 004 <user> :-\n:tmi.twitch.tv 375 <user> :-\n:tmi.twitch.tv 372 <user> :You are in a maze of twisty passages.\n:tmi.twitch.tv 376 <user> :>",
   "CLEARCHAT": {
     "CHANNEL": ":tmi.twitch.tv CLEARCHAT #dallas",
     "USER_WITH_REASON": "@ban-reason=Follow\\sthe\\srules :tmi.twitch.tv CLEARCHAT #dallas :ronni",

--- a/__mocks__/ws/index.js
+++ b/__mocks__/ws/index.js
@@ -85,8 +85,10 @@ class WebSocket extends EventEmitter {
   }
 
   close() {
-    server.emit('close')
     this.readyState = 4
+
+    server.emit('close')
+    this.emit('close')
   }
 }
 

--- a/__mocks__/ws/index.js
+++ b/__mocks__/ws/index.js
@@ -65,7 +65,11 @@ class WebSocket extends EventEmitter {
       case 'NICK': {
         // Mock successful connections.
         if (this.isTokenValid) {
-          this.emit('message', tags.GLOBALUSERSTATE)
+          this.emit('message', commands.WELCOME.replace(/<user>/g, args[0]))
+
+          if (!args[0].startsWith('justinfan')) {
+            this.emit('message', tags.GLOBALUSERSTATE)
+          }
         }
         break
       }

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -229,7 +229,7 @@ Chat client
     * [.reconnect([options])](#Chat+reconnect) ⇒ <code>Promise.&lt;Array.&lt;ChannelState&gt;, string&gt;</code>
     * [.join(channel)](#Chat+join) ⇒ <code>Promise.&lt;ChannelState, string&gt;</code>
     * [.part(channel)](#Chat+part)
-    * [.say(channel, message)](#Chat+say) ⇒ <code>Promise.&lt;UserStateMessage, string&gt;</code>
+    * [.say(channel, message)](#Chat+say) ⇒ <code>Promise.&lt;?UserStateMessage, string&gt;</code>
     * [.whisper(user, message)](#Chat+whisper) ⇒ <code>Promise.&lt;undefined&gt;</code>
     * [.broadcast(message)](#Chat+broadcast) ⇒ <code>Promise.&lt;Array.&lt;UserStateMessage&gt;&gt;</code>
     * ["*"](#Chat+event_*)
@@ -464,7 +464,7 @@ Depart from a channel.
 
 <a name="Chat+say"></a>
 
-### chat.say(channel, message) ⇒ <code>Promise.&lt;UserStateMessage, string&gt;</code>
+### chat.say(channel, message) ⇒ <code>Promise.&lt;?UserStateMessage, string&gt;</code>
 Send a message to a channel.
 
 **Kind**: instance method of [<code>Chat</code>](class#Chat)  

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -223,7 +223,7 @@ Chat client
 * [Chat](#Chat) ⇐ [<code>EventEmitter3</code>](external#external_EventEmitter3)
     * [new Chat(options)](#new_Chat_new)
     * [.updateOptions(options)](#Chat+updateOptions)
-    * [.connect()](#Chat+connect) ⇒ <code>Promise.&lt;GlobalUserStateMessage, string&gt;</code>
+    * [.connect()](#Chat+connect) ⇒ <code>Promise.&lt;?GlobalUserStateMessage, string&gt;</code>
     * [.send(message)](#Chat+send)
     * [.disconnect()](#Chat+disconnect)
     * [.reconnect([options])](#Chat+reconnect) ⇒ <code>Promise.&lt;Array.&lt;ChannelState&gt;, string&gt;</code>
@@ -329,11 +329,11 @@ Update client options.
 
 <a name="Chat+connect"></a>
 
-### chat.connect() ⇒ <code>Promise.&lt;GlobalUserStateMessage, string&gt;</code>
+### chat.connect() ⇒ <code>Promise.&lt;?GlobalUserStateMessage, string&gt;</code>
 Connect to Twitch.
 
 **Kind**: instance method of [<code>Chat</code>](class#Chat)  
-**Returns**: <code>Promise.&lt;GlobalUserStateMessage, string&gt;</code> - Global user state message  
+**Returns**: <code>Promise.&lt;?GlobalUserStateMessage, string&gt;</code> - Global user state message  
 
 * * *
 

--- a/docs/reference/class.md
+++ b/docs/reference/class.md
@@ -232,6 +232,7 @@ Chat client
     * [.say(channel, message)](#Chat+say) ⇒ <code>Promise.&lt;?UserStateMessage, string&gt;</code>
     * [.whisper(user, message)](#Chat+whisper) ⇒ <code>Promise.&lt;undefined&gt;</code>
     * [.broadcast(message)](#Chat+broadcast) ⇒ <code>Promise.&lt;Array.&lt;UserStateMessage&gt;&gt;</code>
+    * [.isUserAuthenticated()](#Chat+isUserAuthenticated) ⇒ <code>Promise</code>
     * ["*"](#Chat+event_*)
     * ["JOIN"](#Chat+event_JOIN)
     * ["PART"](#Chat+event_PART)
@@ -526,6 +527,15 @@ Broadcast message to all connected channels.
     </tr>  </tbody>
 </table>
 
+
+* * *
+
+<a name="Chat+isUserAuthenticated"></a>
+
+### chat.isUserAuthenticated() ⇒ <code>Promise</code>
+Ensure the user is authenticated.
+
+**Kind**: instance method of [<code>Chat</code>](class#Chat)  
 
 * * *
 

--- a/docs/reference/typedef.md
+++ b/docs/reference/typedef.md
@@ -396,9 +396,9 @@ Chat options
   </thead>
   <tbody>
 <tr>
-    <td>username</td><td><code>string</code></td><td></td><td></td>
+    <td>[username]</td><td><code>string</code></td><td></td><td></td>
     </tr><tr>
-    <td>token</td><td><code>string</code></td><td></td><td><p>OAuth token (use <a href="https://twitchapps.com/tmi/">https://twitchapps.com/tmi/</a> to generate one)</p>
+    <td>[token]</td><td><code>string</code></td><td></td><td><p>OAuth token (use <a href="https://twitchapps.com/tmi/">https://twitchapps.com/tmi/</a> to generate one)</p>
 </td>
     </tr><tr>
     <td>[connectionTimeout]</td><td><code>number</code></td><td><code>CONNECTION_TIMEOUT</code></td><td></td>

--- a/src/Chat/Client.js
+++ b/src/Chat/Client.js
@@ -151,6 +151,7 @@ function handleError(messageEvent) {
     messageEvent,
   }
 
+  this.emit(constants.EVENTS.ERROR_ENCOUNTERED, message)
   this.emit(constants.EVENTS.ALL, message)
 }
 
@@ -161,6 +162,7 @@ function handleClose(messageEvent) {
     messageEvent,
   }
 
+  this.emit(constants.EVENTS.DISCONNECTED, message)
   this.emit(constants.EVENTS.ALL, message)
 }
 

--- a/src/Chat/Client.js
+++ b/src/Chat/Client.js
@@ -101,7 +101,7 @@ function handleMessage(options, messageEvent) {
         }
 
         // Handle successful connections.
-        if (utils.isAnonymousUsername(options.username)) {
+        if (utils.isUserAnonymous(options.username)) {
           if (message.command === constants.COMMANDS.WELCOME) {
             this.emit(constants.EVENTS.CONNECTED, {
               command: constants.EVENTS.CONNECTED,

--- a/src/Chat/Client.js
+++ b/src/Chat/Client.js
@@ -28,7 +28,7 @@ class Client extends EventEmitter {
     this.isReady = () => ws.readyState === 1
 
     ws.onopen = handleOpen.bind(this, options)
-    ws.onmessage = handleMessage.bind(this)
+    ws.onmessage = handleMessage.bind(this, options)
     ws.onerror = handleError.bind(this)
     ws.onclose = handleClose.bind(this)
 
@@ -73,11 +73,11 @@ function handleOpen(options) {
   this.send(`CAP REQ :${constants.CAPABILITIES.join(' ')}`, { priority })
 
   // Authenticate.
-  this.send(`PASS ${options.oauth}`, { priority })
+  this.send(`PASS ${options.password}`, { priority })
   this.send(`NICK ${options.username}`, { priority })
 }
 
-function handleMessage(messageEvent) {
+function handleMessage(options, messageEvent) {
   const rawMessage = messageEvent.data
 
   try {
@@ -86,34 +86,43 @@ function handleMessage(messageEvent) {
     const messages = baseParser(rawMessage)
 
     messages.forEach(message => {
-      // Handle PING/PONG.
-      if (message.command === constants.COMMANDS.PING) {
-        this.send('PONG :tmi.twitch.tv', { priority })
-      }
-
-      // Handle successful connections.
-      if (message.command === constants.COMMANDS.GLOBAL_USER_STATE) {
-        this.emit(constants.EVENTS.CONNECTED, {
-          ...message,
-          command: constants.EVENTS.CONNECTED,
-        })
-      }
-
       // Handle authentication failure.
       if (utils.isAuthenticationFailedMessage(message)) {
         this.emit(constants.EVENTS.AUTHENTICATION_FAILED, {
           ...message,
           event: constants.EVENTS.AUTHENTICATION_FAILED,
         })
-        this.disconnect()
-      }
 
-      // Handle RECONNECT.
-      if (message.command === constants.COMMANDS.RECONNECT) {
-        this.emit(constants.EVENTS.RECONNECT, {
-          ...message,
-          command: constants.EVENTS.RECONNECT,
-        })
+        this.disconnect()
+      } else {
+        // Handle PING/PONG.
+        if (message.command === constants.COMMANDS.PING) {
+          this.send('PONG :tmi.twitch.tv', { priority })
+        }
+
+        // Handle successful connections.
+        if (utils.isAnonymousUsername(options.username)) {
+          if (message.command === constants.COMMANDS.WELCOME) {
+            this.emit(constants.EVENTS.CONNECTED, {
+              command: constants.EVENTS.CONNECTED,
+            })
+          }
+        } else {
+          if (message.command === constants.COMMANDS.GLOBAL_USER_STATE) {
+            this.emit(constants.EVENTS.CONNECTED, {
+              ...message,
+              command: constants.EVENTS.CONNECTED,
+            })
+          }
+        }
+
+        // Handle RECONNECT.
+        if (message.command === constants.COMMANDS.RECONNECT) {
+          this.emit(constants.EVENTS.RECONNECT, {
+            ...message,
+            command: constants.EVENTS.RECONNECT,
+          })
+        }
       }
 
       // Emit all messages.

--- a/src/Chat/Client.js
+++ b/src/Chat/Client.js
@@ -73,7 +73,7 @@ function handleOpen(options) {
   this.send(`CAP REQ :${constants.CAPABILITIES.join(' ')}`, { priority })
 
   // Authenticate.
-  this.send(`PASS ${options.password}`, { priority })
+  this.send(`PASS ${options.oauth}`, { priority })
   this.send(`NICK ${options.username}`, { priority })
 }
 

--- a/src/Chat/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Chat/__tests__/__snapshots__/index.test.js.snap
@@ -996,7 +996,7 @@ Object {
 }
 `;
 
-exports[`Chat should handle messages PRIVMSG whisper when anonymous 1`] = `"Not authenticated"`;
+exports[`Chat should handle messages PRIVMSG whisper when anonymous 1`] = `[Error: Not authenticated]`;
 
 exports[`Chat should handle messages USERNOTICE GIFT_PAID_UPGRADE 1`] = `
 Object {
@@ -1401,7 +1401,7 @@ Object {
 }
 `;
 
-exports[`Chat should handle multiple channels should deny message broadcasting when anonymous 1`] = `"Not authenticated"`;
+exports[`Chat should handle multiple channels should deny message broadcasting when anonymous 1`] = `[Error: Not authenticated]`;
 
 exports[`Chat should join channel 1`] = `
 Object {
@@ -1449,4 +1449,4 @@ Object {
 }
 `;
 
-exports[`Chat should throw when sending a message as anonymous 1`] = `"Not authenticated"`;
+exports[`Chat should throw when sending a message as anonymous 1`] = `[Error: Not authenticated]`;

--- a/src/Chat/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Chat/__tests__/__snapshots__/index.test.js.snap
@@ -1391,6 +1391,8 @@ Object {
 }
 `;
 
+exports[`Chat should handle multiple channels should deny message broadcasting when anonymous 1`] = `"Not authenticated"`;
+
 exports[`Chat should join channel 1`] = `
 Object {
   "roomState": Object {

--- a/src/Chat/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Chat/__tests__/__snapshots__/index.test.js.snap
@@ -1,6 +1,12 @@
 // Jest Snapshot v1, https://goo.gl/fbAQLP
 
-exports[`Chat connect should connect 1`] = `
+exports[`Chat connect should connect as anonymous 1`] = `
+Object {
+  "command": "CONNECTED",
+}
+`;
+
+exports[`Chat connect should connect as authenticated 1`] = `
 Object {
   "_raw": "@color=#0D4200;display-name=dallas;emote-sets=0,33,50,237,793,2126,3517,4578,5569,9400,10337,12239;turbo=0;user-id=1337;user-type=admin :tmi.twitch.tv GLOBALUSERSTATE",
   "channel": undefined,
@@ -43,6 +49,83 @@ Array [
 
 exports[`Chat reconnect should reconnect and rejoin channels 2`] = `
 Array [
+  Array [
+    Object {
+      "_raw": ":tmi.twitch.tv 001 USERNAME :Welcome, GLHF!",
+      "channel": "USERNAME",
+      "command": "001",
+      "isSelf": false,
+      "message": "Welcome, GLHF!",
+      "tags": Object {},
+      "timestamp": 2018-01-01T00:00:00.000Z,
+    },
+  ],
+  Array [
+    Object {
+      "_raw": ":tmi.twitch.tv 002 USERNAME :Your host is tmi.twitch.tv",
+      "channel": "USERNAME",
+      "command": "002",
+      "isSelf": false,
+      "message": "Your host is tmi.twitch.tv",
+      "tags": Object {},
+      "timestamp": 2018-01-01T00:00:00.000Z,
+    },
+  ],
+  Array [
+    Object {
+      "_raw": ":tmi.twitch.tv 003 USERNAME :This server is rather new",
+      "channel": "USERNAME",
+      "command": "003",
+      "isSelf": false,
+      "message": "This server is rather new",
+      "tags": Object {},
+      "timestamp": 2018-01-01T00:00:00.000Z,
+    },
+  ],
+  Array [
+    Object {
+      "_raw": ":tmi.twitch.tv 004 USERNAME :-",
+      "channel": "USERNAME",
+      "command": "004",
+      "isSelf": false,
+      "message": "-",
+      "tags": Object {},
+      "timestamp": 2018-01-01T00:00:00.000Z,
+    },
+  ],
+  Array [
+    Object {
+      "_raw": ":tmi.twitch.tv 375 USERNAME :-",
+      "channel": "USERNAME",
+      "command": "375",
+      "isSelf": false,
+      "message": "-",
+      "tags": Object {},
+      "timestamp": 2018-01-01T00:00:00.000Z,
+    },
+  ],
+  Array [
+    Object {
+      "_raw": ":tmi.twitch.tv 372 USERNAME :You are in a maze of twisty passages.",
+      "channel": "USERNAME",
+      "command": "372",
+      "isSelf": false,
+      "message": "You are in a maze of twisty passages.",
+      "tags": Object {},
+      "timestamp": 2018-01-01T00:00:00.000Z,
+    },
+  ],
+  Array [
+    Object {
+      "_raw": ":tmi.twitch.tv 376 USERNAME :>",
+      "channel": "USERNAME",
+      "command": "376",
+      "isSelf": false,
+      "message": ">",
+      "tags": Object {},
+      "timestamp": 2018-01-01T00:00:00.000Z,
+    },
+  ],
   Array [
     Object {
       "_raw": "@color=#0D4200;display-name=dallas;emote-sets=0,33,50,237,793,2126,3517,4578,5569,9400,10337,12239;turbo=0;user-id=1337;user-type=admin :tmi.twitch.tv GLOBALUSERSTATE",

--- a/src/Chat/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Chat/__tests__/__snapshots__/index.test.js.snap
@@ -51,6 +51,16 @@ exports[`Chat reconnect should reconnect and rejoin channels 2`] = `
 Array [
   Array [
     Object {
+      "event": "DISCONNECTED",
+      "isSelf": false,
+      "messageEvent": Object {
+        "data": undefined,
+      },
+      "timestamp": 2018-01-01T00:00:00.000Z,
+    },
+  ],
+  Array [
+    Object {
       "_raw": ":tmi.twitch.tv 001 USERNAME :Welcome, GLHF!",
       "channel": "USERNAME",
       "command": "001",

--- a/src/Chat/__tests__/__snapshots__/index.test.js.snap
+++ b/src/Chat/__tests__/__snapshots__/index.test.js.snap
@@ -986,6 +986,8 @@ Object {
 }
 `;
 
+exports[`Chat should handle messages PRIVMSG whisper when anonymous 1`] = `"Not authenticated"`;
+
 exports[`Chat should handle messages USERNOTICE GIFT_PAID_UPGRADE 1`] = `
 Object {
   "_raw": "@badges=subscriber/0,premium/1;color=#8A2BE2;display-name=ElizabethSwann;emotes=;id=5bd3e064-c1e4-451b-9d7e-afe8cf5a44a2;login=elizabethswann;mod=0;msg-id=giftpaidupgrade;msg-param-promo-gift-total=123816;msg-param-promo-name=Subtember;msg-param-sender-login=cannibulcake;msg-param-sender-name=CannibulCake;room-id=7236692;subscriber=1;system-msg=ElizabethSwann\\\\sis\\\\scontinuing\\\\sthe\\\\sGift\\\\sSub\\\\sthey\\\\sgot\\\\sfrom\\\\sCannibulCake!\\\\sThey're\\\\sone\\\\sof\\\\s123816\\\\sgift\\\\ssubs\\\\sto\\\\scontinue\\\\sthis\\\\sSubtember.;tmi-sent-ts=1536880884587;turbo=0;user-id=85946347;user-type= :tmi.twitch.tv USERNOTICE #dansgaming",
@@ -1434,3 +1436,5 @@ Object {
   },
 }
 `;
+
+exports[`Chat should throw when sending a message as anonymous 1`] = `"Not authenticated"`;

--- a/src/Chat/__tests__/index.test.js
+++ b/src/Chat/__tests__/index.test.js
@@ -43,7 +43,7 @@ describe('Chat', () => {
       const actual = await chat.connect()
 
       expect(actual).toMatchSnapshot()
-      expect(chat.readyState).toBe('CONNECTED')
+      expect(chat.readyState).toBe(3)
     })
 
     test('should connect as authenticated', async () => {
@@ -51,7 +51,7 @@ describe('Chat', () => {
       const actual = await chat.connect()
 
       expect(actual).toMatchSnapshot()
-      expect(chat.readyState).toBe('CONNECTED')
+      expect(chat.readyState).toBe(3)
     })
 
     test('should call onAuthenticationFailure', done => {
@@ -161,7 +161,7 @@ describe('Chat', () => {
     expect.assertions(2)
 
     chat.once(constants.EVENTS.DISCONNECTED, () => {
-      expect(chat.readyState).toBe('DISCONNECTED')
+      expect(chat.readyState).toBe(5)
       expect(chat._connectPromise).toBe(null)
       done()
     })

--- a/src/Chat/__tests__/index.test.js
+++ b/src/Chat/__tests__/index.test.js
@@ -158,7 +158,13 @@ describe('Chat', () => {
     const chat = new Chat(options)
     await chat.connect()
 
-    server.once('close', () => done())
+    expect.assertions(2)
+
+    chat.once(constants.EVENTS.DISCONNECTED, () => {
+      expect(chat.readyState).toBe('DISCONNECTED')
+      expect(chat._connectPromise).toBe(null)
+      done()
+    })
 
     chat.disconnect()
   })

--- a/src/Chat/__tests__/index.test.js
+++ b/src/Chat/__tests__/index.test.js
@@ -131,9 +131,9 @@ describe('Chat', () => {
     const chat = new Chat({})
     await chat.connect()
 
-    expect(() =>
+    await expect(
       chat.say('#dallas', 'Kappa Keepo Kappa'),
-    ).toThrowErrorMatchingSnapshot()
+    ).rejects.toMatchSnapshot()
   })
 
   test('should part a channel', async done => {
@@ -446,9 +446,9 @@ describe('Chat', () => {
         const chat = new Chat({})
         await chat.connect()
 
-        expect(() =>
+        await expect(
           chat.whisper('dallas', 'Kappa Keepo Kappa'),
-        ).toThrowErrorMatchingSnapshot()
+        ).rejects.toMatchSnapshot()
       })
     })
 
@@ -477,9 +477,9 @@ describe('Chat', () => {
       const chat = new Chat({})
       await chat.connect()
 
-      expect(() =>
+      await expect(
         chat.broadcast('Kappa Keepo Kappa'),
-      ).toThrowErrorMatchingSnapshot()
+      ).rejects.toMatchSnapshot()
     })
   })
 })

--- a/src/Chat/__tests__/index.test.js
+++ b/src/Chat/__tests__/index.test.js
@@ -38,7 +38,13 @@ describe('Chat', () => {
   })
 
   describe('connect', () => {
-    test('should connect', async () => {
+    test('should connect as anonymous', async () => {
+      const chat = new Chat({})
+      const actual = await chat.connect()
+      expect(actual).toMatchSnapshot()
+    })
+
+    test('should connect as authenticated', async () => {
       const chat = new Chat(options)
       const actual = await chat.connect()
       expect(actual).toMatchSnapshot()

--- a/src/Chat/__tests__/index.test.js
+++ b/src/Chat/__tests__/index.test.js
@@ -454,5 +454,14 @@ describe('Chat', () => {
   describe('should handle multiple channels', () => {
     // test('should join multiple channels', () => {})
     // test('should broadcast message to all channels', () => {})
+
+    test('should deny message broadcasting when anonymous', async () => {
+      const chat = new Chat({})
+      await chat.connect()
+
+      expect(() =>
+        chat.broadcast('Kappa Keepo Kappa'),
+      ).toThrowErrorMatchingSnapshot()
+    })
   })
 })

--- a/src/Chat/__tests__/index.test.js
+++ b/src/Chat/__tests__/index.test.js
@@ -115,6 +115,15 @@ describe('Chat', () => {
     chat.say('#dallas', 'Kappa Keepo Kappa')
   })
 
+  test('should throw when sending a message as anonymous', async () => {
+    const chat = new Chat({})
+    await chat.connect()
+
+    expect(() =>
+      chat.say('#dallas', 'Kappa Keepo Kappa'),
+    ).toThrowErrorMatchingSnapshot()
+  })
+
   test('should part a channel', async done => {
     const chat = new Chat(options)
     await chat.connect()
@@ -413,6 +422,15 @@ describe('Chat', () => {
         })
 
         chat.whisper('dallas', 'Kappa Keepo Kappa')
+      })
+
+      test('whisper when anonymous', async () => {
+        const chat = new Chat({})
+        await chat.connect()
+
+        expect(() =>
+          chat.whisper('dallas', 'Kappa Keepo Kappa'),
+        ).toThrowErrorMatchingSnapshot()
       })
     })
 

--- a/src/Chat/__tests__/index.test.js
+++ b/src/Chat/__tests__/index.test.js
@@ -41,13 +41,17 @@ describe('Chat', () => {
     test('should connect as anonymous', async () => {
       const chat = new Chat({})
       const actual = await chat.connect()
+
       expect(actual).toMatchSnapshot()
+      expect(chat.readyState).toBe('CONNECTED')
     })
 
     test('should connect as authenticated', async () => {
       const chat = new Chat(options)
       const actual = await chat.connect()
+
       expect(actual).toMatchSnapshot()
+      expect(chat.readyState).toBe('CONNECTED')
     })
 
     test('should call onAuthenticationFailure', done => {
@@ -80,6 +84,14 @@ describe('Chat', () => {
         expect(chat.options.token).toEqual('TOKEN')
         done()
       })
+    })
+
+    test('should return the same promise', async () => {
+      const chat = new Chat(options)
+      const actual = chat.connect()
+      const expected = chat.connect()
+
+      expect(actual).toEqual(expected)
     })
   })
 

--- a/src/Chat/constants.js
+++ b/src/Chat/constants.js
@@ -43,6 +43,7 @@ export const MESSAGE_PARAMETER_PREFIX_RE = new RegExp(
 export const PRIVATE_MESSAGE_HOSTED_RE = /:.+@jtv\.tmi\.twitch\.tv PRIVMSG #?(\w+) :(\w+) is now (?:(auto) )?hosting[A-z ]+(\d+)?/
 
 export const ANONYMOUS_USERNAME = 'justinfan'
+export const ANONYMOUS_USERNAME_RE = new RegExp(`^${ANONYMOUS_USERNAME}(\\d+)$`)
 
 /** @typedef {string} ClientReadyState */
 /**

--- a/src/Chat/constants.js
+++ b/src/Chat/constants.js
@@ -42,6 +42,8 @@ export const MESSAGE_PARAMETER_PREFIX_RE = new RegExp(
 )
 export const PRIVATE_MESSAGE_HOSTED_RE = /:.+@jtv\.tmi\.twitch\.tv PRIVMSG #?(\w+) :(\w+) is now (?:(auto) )?hosting[A-z ]+(\d+)?/
 
+export const ANONYMOUS_USERNAME = 'justinfan'
+
 /** @typedef {string} ClientReadyState */
 /**
  * Chat client ready state
@@ -89,6 +91,7 @@ export const TAG_COMMANDS = {
 }
 
 export const OTHER_COMMANDS = {
+  WELCOME: '001',
   PING: 'PING',
   PONG: 'PONG',
   WHISPER: 'PRIVMSG #jtv',

--- a/src/Chat/index.js
+++ b/src/Chat/index.js
@@ -296,7 +296,7 @@ class Chat extends EventEmitter {
       utils.onceResolve(this, `${constants.COMMANDS.ROOM_STATE}/${channel}`),
     ]
 
-    if (!chatUtils.isAnonymousUsername(this.options.username)) {
+    if (!chatUtils.isUserAnonymous(this.options.username)) {
       promises.push(
         utils.onceResolve(this, `${constants.COMMANDS.USER_STATE}/${channel}`),
       )
@@ -349,7 +349,7 @@ class Chat extends EventEmitter {
    * @return {Promise<?UserStateMessage, string>}
    */
   say(maybeChannel, message) {
-    if (chatUtils.isAnonymousUsername(this.options.username)) {
+    if (chatUtils.isUserAnonymous(this.options.username)) {
       throw new Error('Not authenticated')
     }
 
@@ -382,7 +382,7 @@ class Chat extends EventEmitter {
    * @return {Promise<undefined>}
    */
   whisper(user, message) {
-    if (chatUtils.isAnonymousUsername(this.options.username)) {
+    if (chatUtils.isUserAnonymous(this.options.username)) {
       throw new Error('Not authenticated')
     }
 
@@ -395,7 +395,7 @@ class Chat extends EventEmitter {
    * @return {Promise<Array<UserStateMessage>>}
    */
   broadcast(message) {
-    if (chatUtils.isAnonymousUsername(this.options.username)) {
+    if (chatUtils.isUserAnonymous(this.options.username)) {
       throw new Error('Not authenticated')
     }
 

--- a/src/Chat/index.js
+++ b/src/Chat/index.js
@@ -574,7 +574,7 @@ function handleMessage(baseMessage) {
 
 function handleDisconnect() {
   this._connectPromise = null
-  this._readyState = 4
+  this._readyState = 5
 }
 
 export { constants }

--- a/src/Chat/index.js
+++ b/src/Chat/index.js
@@ -501,7 +501,7 @@ function handleMessage(baseMessage) {
       message = parsers.modeMessage(preMessage)
       eventName = `${message.command}/${channel}`
 
-      if (message.username === this.userState.username) {
+      if (this.userState && message.username === this.userState.username) {
         const channelState = this.getChannelState(channel)
 
         this.setChannelState(channel, {

--- a/src/Chat/index.js
+++ b/src/Chat/index.js
@@ -360,15 +360,11 @@ class Chat extends EventEmitter {
     }
 
     const channel = sanitizers.channel(maybeChannel)
-    const promises = [this.connect]
 
-    if (chatUtils.isAnonymousUsername(this.options.username)) {
-      promises.push(
-        utils.onceResolve(this, `${constants.COMMANDS.USER_STATE}/${channel}`),
-      )
-    }
-
-    const say = Promise.all(promises)
+    const say = Promise.all([
+      this.connect,
+      utils.onceResolve(this, `${constants.COMMANDS.USER_STATE}/${channel}`),
+    ])
 
     const send = this.send(
       `${constants.COMMANDS.PRIVATE_MESSAGE} ${channel} :${message}`,

--- a/src/Chat/index.js
+++ b/src/Chat/index.js
@@ -129,7 +129,7 @@ class Chat extends EventEmitter {
   }
 
   get readyState() {
-    return constants.READY_STATES[this._readyState]
+    return this._readyState
   }
 
   get userState() {

--- a/src/Chat/index.js
+++ b/src/Chat/index.js
@@ -170,14 +170,17 @@ class Chat extends EventEmitter {
 
   /**
    * Connect to Twitch.
-   * @return {Promise<GlobalUserStateMessage, string>} Global user state message
+   * @return {Promise<?GlobalUserStateMessage, string>} Global user state message
    */
   connect() {
     const connect = new Promise((resolve, reject) => {
       if (this.readyState === 1) {
         // Already trying to connect, so resolve when connected.
-        this.once(constants.EVENTS.GLOBAL_USER_STATE, globalUserStateMessage =>
-          resolve(globalUserStateMessage),
+        this.once(
+          chatUtils.isAnonymousUsername(this.options.username)
+            ? constants.EVENTS.CONNECTED
+            : constants.EVENTS.GLOBAL_USER_STATE,
+          resolve,
         )
       } else if (this.readyState === 3) {
         // Already connected.

--- a/src/Chat/index.js
+++ b/src/Chat/index.js
@@ -184,19 +184,33 @@ class Chat extends EventEmitter {
           new Errors.TimeoutError(constants.ERROR_CONNECT_TIMED_OUT),
         ),
         new Promise((resolve, reject) => {
+          // Connect ...
           this._readyState = 1
+
+          // Increment connection attempts.
           this._connectionAttempts += 1
 
           if (this._client) {
+            // Remove all listeners, just in case.
             this._client.removeAllListeners()
           }
 
+          // Create client and connect.
           this._client = new Client(this.options)
 
+          // Handle messages.
           this._client.on(constants.EVENTS.ALL, handleMessage, this)
+
+          // Handle disconnects.
           this._client.on(constants.EVENTS.DISCONNECTED, handleDisconnect, this)
+
+          // Listen for reconnects.
           this._client.once(constants.EVENTS.RECONNECT, () => this.reconnect())
+
+          // Listen for authentication failures.
           this._client.once(constants.EVENTS.AUTHENTICATION_FAILED, reject)
+
+          // Once the client is connected, resolve ...
           this._client.once(constants.EVENTS.CONNECTED, resolve)
         }),
       ])

--- a/src/Chat/utils/__tests__/index.test.js
+++ b/src/Chat/utils/__tests__/index.test.js
@@ -69,4 +69,18 @@ describe('Chat/utils', () => {
       expect(actual).toEqual(expected)
     })
   })
+
+  describe('isAnonymousUsername', () => {
+    test('should return true if anonymous', () => {
+      const actual = utils.isAnonymousUsername('justinfan12345')
+      const expected = true
+      expect(actual).toEqual(expected)
+    })
+
+    test('should return false otherwise', () => {
+      const actual = utils.isAnonymousUsername('lorem_ipsum')
+      const expected = false
+      expect(actual).toEqual(expected)
+    })
+  })
 })

--- a/src/Chat/utils/__tests__/index.test.js
+++ b/src/Chat/utils/__tests__/index.test.js
@@ -70,15 +70,15 @@ describe('Chat/utils', () => {
     })
   })
 
-  describe('isAnonymousUsername', () => {
+  describe('isUserAnonymous', () => {
     test('should return true if anonymous', () => {
-      const actual = utils.isAnonymousUsername('justinfan12345')
+      const actual = utils.isUserAnonymous('justinfan12345')
       const expected = true
       expect(actual).toEqual(expected)
     })
 
     test('should return false otherwise', () => {
-      const actual = utils.isAnonymousUsername('lorem_ipsum')
+      const actual = utils.isUserAnonymous('lorem_ipsum')
       const expected = false
       expect(actual).toEqual(expected)
     })

--- a/src/Chat/utils/__tests__/sanitizers.test.js
+++ b/src/Chat/utils/__tests__/sanitizers.test.js
@@ -24,19 +24,19 @@ describe('Chat/utils/sanitizers', () => {
 
   describe('password', () => {
     test('should return "TWITCHJS"', () => {
-      const actual = sanitizers.password(null)
+      const actual = sanitizers.oauth(null)
       const expected = 'TWITCHJS'
       expect(actual).toEqual(expected)
     })
 
     test('should return the input password', () => {
-      const actual = sanitizers.password('oauth:lorem')
+      const actual = sanitizers.oauth('oauth:lorem')
       const expected = 'oauth:lorem'
       expect(actual).toEqual(expected)
     })
 
     test('should return the password prepended by "oauth:"', () => {
-      const actual = sanitizers.password('lorem')
+      const actual = sanitizers.oauth('lorem')
       const expected = 'oauth:lorem'
       expect(actual).toEqual(expected)
     })

--- a/src/Chat/utils/__tests__/sanitizers.test.js
+++ b/src/Chat/utils/__tests__/sanitizers.test.js
@@ -1,0 +1,64 @@
+import * as utils from '../index'
+import * as sanitizers from '../sanitizers'
+
+describe('Chat/utils/sanitizers', () => {
+  describe('channel', () => {
+    test('should return "#" when null or empty', () => {
+      const actual = sanitizers.channel(null)
+      const expected = '#'
+      expect(actual).toEqual(expected)
+    })
+
+    test('should return the sanitized channel', () => {
+      const actual = sanitizers.channel('lorem')
+      const expected = '#lorem'
+      expect(actual).toEqual(expected)
+    })
+
+    test('should return the input channel', () => {
+      const actual = sanitizers.channel('#lorem')
+      const expected = '#lorem'
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('password', () => {
+    test('should return "SCHMOOPIIE"', () => {
+      const actual = sanitizers.password(null)
+      const expected = 'SCHMOOPIIE'
+      expect(actual).toEqual(expected)
+    })
+
+    test('should return the input password', () => {
+      const actual = sanitizers.password('oauth:lorem')
+      const expected = 'oauth:lorem'
+      expect(actual).toEqual(expected)
+    })
+
+    test('should return the password prepended by "oauth:"', () => {
+      const actual = sanitizers.password('lorem')
+      const expected = 'oauth:lorem'
+      expect(actual).toEqual(expected)
+    })
+  })
+
+  describe('username', () => {
+    test('should return the anonymous username', () => {
+      const actual = sanitizers.username(null)
+      const expected = true
+      expect(utils.isAnonymousUsername(actual)).toBe(expected)
+    })
+
+    test('should return the anonymous username appended with random numbers', () => {
+      const actual = sanitizers.username('justinfan')
+      const expected = true
+      expect(utils.isAnonymousUsername(actual)).toBe(expected)
+    })
+
+    test('should return the input username', () => {
+      const actual = sanitizers.username('lorem')
+      const expected = false
+      expect(utils.isAnonymousUsername(actual)).toBe(expected)
+    })
+  })
+})

--- a/src/Chat/utils/__tests__/sanitizers.test.js
+++ b/src/Chat/utils/__tests__/sanitizers.test.js
@@ -46,19 +46,19 @@ describe('Chat/utils/sanitizers', () => {
     test('should return the anonymous username', () => {
       const actual = sanitizers.username(null)
       const expected = true
-      expect(utils.isAnonymousUsername(actual)).toBe(expected)
+      expect(utils.isUserAnonymous(actual)).toBe(expected)
     })
 
     test('should return the anonymous username appended with random numbers', () => {
       const actual = sanitizers.username('justinfan')
       const expected = true
-      expect(utils.isAnonymousUsername(actual)).toBe(expected)
+      expect(utils.isUserAnonymous(actual)).toBe(expected)
     })
 
     test('should return the input username', () => {
       const actual = sanitizers.username('lorem')
       const expected = false
-      expect(utils.isAnonymousUsername(actual)).toBe(expected)
+      expect(utils.isUserAnonymous(actual)).toBe(expected)
     })
   })
 })

--- a/src/Chat/utils/__tests__/sanitizers.test.js
+++ b/src/Chat/utils/__tests__/sanitizers.test.js
@@ -23,9 +23,9 @@ describe('Chat/utils/sanitizers', () => {
   })
 
   describe('password', () => {
-    test('should return "SCHMOOPIIE"', () => {
+    test('should return "TWITCHJS"', () => {
       const actual = sanitizers.password(null)
-      const expected = 'SCHMOOPIIE'
+      const expected = 'TWITCHJS'
       expect(actual).toEqual(expected)
     })
 

--- a/src/Chat/utils/index.js
+++ b/src/Chat/utils/index.js
@@ -23,8 +23,7 @@ const isAuthenticationFailedMessage = (message = {}) =>
 const getEventNameFromMessage = (message = {}) =>
   message.command || message.event || constants.EVENTS.ALL
 
-const isAnonymousUsername = value =>
-  value.startsWith(constants.ANONYMOUS_USERNAME)
+const isAnonymousUsername = value => constants.ANONYMOUS_USERNAME_RE.test(value)
 
 export {
   getMessageQueueWeight,

--- a/src/Chat/utils/index.js
+++ b/src/Chat/utils/index.js
@@ -23,11 +23,11 @@ const isAuthenticationFailedMessage = (message = {}) =>
 const getEventNameFromMessage = (message = {}) =>
   message.command || message.event || constants.EVENTS.ALL
 
-const isAnonymousUsername = value => constants.ANONYMOUS_USERNAME_RE.test(value)
+const isUserAnonymous = value => constants.ANONYMOUS_USERNAME_RE.test(value)
 
 export {
   getMessageQueueWeight,
   isAuthenticationFailedMessage,
   getEventNameFromMessage,
-  isAnonymousUsername,
+  isUserAnonymous,
 }

--- a/src/Chat/utils/index.js
+++ b/src/Chat/utils/index.js
@@ -23,8 +23,12 @@ const isAuthenticationFailedMessage = (message = {}) =>
 const getEventNameFromMessage = (message = {}) =>
   message.command || message.event || constants.EVENTS.ALL
 
+const isAnonymousUsername = value =>
+  value.startsWith(constants.ANONYMOUS_USERNAME)
+
 export {
   getMessageQueueWeight,
   isAuthenticationFailedMessage,
   getEventNameFromMessage,
+  isAnonymousUsername,
 }

--- a/src/Chat/utils/sanitizers.js
+++ b/src/Chat/utils/sanitizers.js
@@ -13,7 +13,7 @@ function channel(value) {
   return `#${value}`
 }
 
-function password(value) {
+function oauth(value) {
   if (value == null) {
     return 'TWITCHJS'
   }
@@ -33,4 +33,4 @@ function username(value) {
   return value
 }
 
-export { channel, password, username }
+export { channel, oauth, username }

--- a/src/Chat/utils/sanitizers.js
+++ b/src/Chat/utils/sanitizers.js
@@ -1,6 +1,35 @@
-import { replace, toLower } from 'lodash'
+import { ANONYMOUS_USERNAME } from '../constants'
 
-const oauth = (oauth = '') => `oauth:${replace(oauth, /oauth:/gi, '')}`
-const channel = (channel = '') => `#${replace(toLower(channel), /^#/g, '')}`
+function channel(value) {
+  if (value == null) {
+    return '#'
+  }
 
-export { oauth, channel }
+  if (value.startsWith('#')) {
+    return value
+  }
+
+  return `#${channel}`
+}
+
+function password(value) {
+  if (value == null || value === 'SCHMOOPIIE') {
+    return 'SCHMOOPIIE'
+  }
+
+  if (value.startsWith('oauth:')) {
+    return value
+  }
+
+  return `oauth:${value}`
+}
+
+function username(value) {
+  if (value == null) {
+    return `${ANONYMOUS_USERNAME}{Math.floor(Math.random() * 80000 + 1000)}`
+  }
+
+  return value
+}
+
+export { channel, password, username }

--- a/src/Chat/utils/sanitizers.js
+++ b/src/Chat/utils/sanitizers.js
@@ -9,7 +9,7 @@ function channel(value) {
     return value
   }
 
-  return `#${channel}`
+  return `#${value}`
 }
 
 function password(value) {
@@ -25,8 +25,8 @@ function password(value) {
 }
 
 function username(value) {
-  if (value == null) {
-    return `${ANONYMOUS_USERNAME}{Math.floor(Math.random() * 80000 + 1000)}`
+  if (value == null || value === 'justinfan') {
+    return `${ANONYMOUS_USERNAME}${Math.floor(Math.random() * 80000 + 1000)}`
   }
 
   return value

--- a/src/Chat/utils/sanitizers.js
+++ b/src/Chat/utils/sanitizers.js
@@ -14,8 +14,8 @@ function channel(value) {
 }
 
 function password(value) {
-  if (value == null || value === 'SCHMOOPIIE') {
-    return 'SCHMOOPIIE'
+  if (value == null) {
+    return 'TWITCHJS'
   }
 
   if (value.startsWith('oauth:')) {

--- a/src/Chat/utils/sanitizers.js
+++ b/src/Chat/utils/sanitizers.js
@@ -1,3 +1,4 @@
+import { random } from 'lodash'
 import { ANONYMOUS_USERNAME } from '../constants'
 
 function channel(value) {
@@ -26,7 +27,7 @@ function password(value) {
 
 function username(value) {
   if (value == null || value === 'justinfan') {
-    return `${ANONYMOUS_USERNAME}${Math.floor(Math.random() * 80000 + 1000)}`
+    return `${ANONYMOUS_USERNAME}${random(80000, 81000)}`
   }
 
   return value

--- a/src/Chat/utils/validators.js
+++ b/src/Chat/utils/validators.js
@@ -2,7 +2,7 @@ import invariant from 'invariant'
 
 import {
   conformsTo,
-  defaultsDeep,
+  defaults,
   isString,
   isFinite,
   isFunction,
@@ -16,25 +16,28 @@ const chatOptions = maybeOptions => {
   /**
    * Chat options
    * @typedef {Object} ChatOptions
-   * @property {string} username
-   * @property {string} token OAuth token (use {@link https://twitchapps.com/tmi/} to generate one)
+   * @property {string} [username]
+   * @property {string} [token] OAuth token (use {@link https://twitchapps.com/tmi/} to generate one)
    * @property {number} [connectionTimeout=CONNECTION_TIMEOUT]
    * @property {number} [joinTimeout=JOIN_TIMEOUT]
    * @property {boolean} [debug=false]
-   * @property {function} [onAuthenticationFailure]
+   * @property {Function} [onAuthenticationFailure]
    */
   const shape = {
     username: isString,
-    token: isString,
+    password: isString,
     connectionTimeout: isFinite,
     joinTimeout: isFinite,
     debug: isBoolean,
     onAuthenticationFailure: isFunction,
   }
 
-  const options = defaultsDeep(
-    {},
-    { ...maybeOptions, oauth: sanitizers.oauth(maybeOptions.token) },
+  const options = defaults(
+    {
+      ...maybeOptions,
+      username: sanitizers.username(maybeOptions.username),
+      password: sanitizers.password(maybeOptions.token),
+    },
     {
       connectionTimeout: constants.CONNECTION_TIMEOUT,
       joinTimeout: constants.JOIN_TIMEOUT,
@@ -54,15 +57,18 @@ const chatOptions = maybeOptions => {
 const clientOptions = maybeOptions => {
   const shape = {
     username: isString,
-    oauth: isString,
+    password: isString,
     server: isString,
     port: isFinite,
     ssl: isBoolean,
   }
 
-  const options = defaultsDeep(
-    {},
-    { ...maybeOptions, oauth: sanitizers.oauth(maybeOptions.token) },
+  const options = defaults(
+    {
+      ...maybeOptions,
+      username: sanitizers.username(maybeOptions.username),
+      password: sanitizers.password(maybeOptions.token),
+    },
     {
       server: constants.CHAT_SERVER,
       port: constants.CHAT_SERVER_SSL_PORT,

--- a/src/Chat/utils/validators.js
+++ b/src/Chat/utils/validators.js
@@ -36,7 +36,6 @@ const chatOptions = maybeOptions => {
     {
       ...maybeOptions,
       username: sanitizers.username(maybeOptions.username),
-      password: sanitizers.password(maybeOptions.token),
     },
     {
       connectionTimeout: constants.CONNECTION_TIMEOUT,

--- a/src/Chat/utils/validators.js
+++ b/src/Chat/utils/validators.js
@@ -7,6 +7,7 @@ import {
   isFinite,
   isFunction,
   isBoolean,
+  isNil,
 } from 'lodash'
 
 import * as constants from '../constants'
@@ -25,7 +26,7 @@ const chatOptions = maybeOptions => {
    */
   const shape = {
     username: isString,
-    password: isString,
+    token: value => isNil(value) || isString(value),
     connectionTimeout: isFinite,
     joinTimeout: isFinite,
     debug: isBoolean,

--- a/src/Chat/utils/validators.js
+++ b/src/Chat/utils/validators.js
@@ -37,8 +37,10 @@ const chatOptions = maybeOptions => {
     {
       ...maybeOptions,
       username: sanitizers.username(maybeOptions.username),
+      oauth: sanitizers.oauth(maybeOptions.token),
     },
     {
+      token: null,
       connectionTimeout: constants.CONNECTION_TIMEOUT,
       joinTimeout: constants.JOIN_TIMEOUT,
       debug: false,
@@ -57,7 +59,7 @@ const chatOptions = maybeOptions => {
 const clientOptions = maybeOptions => {
   const shape = {
     username: isString,
-    password: isString,
+    oauth: isString,
     server: isString,
     port: isFinite,
     ssl: isBoolean,
@@ -67,7 +69,7 @@ const clientOptions = maybeOptions => {
     {
       ...maybeOptions,
       username: sanitizers.username(maybeOptions.username),
-      password: sanitizers.password(maybeOptions.token),
+      oauth: sanitizers.oauth(maybeOptions.token),
     },
     {
       server: constants.CHAT_SERVER,


### PR DESCRIPTION
## Proposed changes

Closes #146.

## Types of changes

* [x] New feature (non-breaking change which adds functionality)

## Checklist

* [x] I have read the [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] My PR is named according to [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules

## Further comments

The GLOBALUSERSTATE event is only sent when the user is authenticated.
I wonder if that would be better if we don't have to wait for the GLOBALUSERSTATE event in order to have a better workflow to deal with both situations. I mean, removing the global user state resolution from the connection process would be cleaner, so we just have to deal with the WELCOME message.
Still, people can get it by listening to the associated event anyway.