### PR TITLE
Bugfix: enable coercion support for browser build

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -31,10 +31,10 @@ module.exports = (env = {}, argv) => {
 
     plugins: isProd
       ? [
-          new LodashModuleReplacementPlugin({ paths: true }),
+          new LodashModuleReplacementPlugin({ coercions: true, paths: true }),
           new MinifyPlugin({}, { sourceMap: 'source-map' }),
           new CompressionPlugin(),
         ]
-      : [new LodashModuleReplacementPlugin({ paths: true })],
+      : [new LodashModuleReplacementPlugin({ coercions: true, paths: true })],
   };
 };


### PR DESCRIPTION
## Proposed changes

With the Helix support, the browser build broke.
It's caused by the Lodash replacement plugin which doesn't coerce values. This change enables the coercion support for the browser build.
If this solution isn't good, it's possible to check the type instead.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

* [x] I have read the [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] My PR is named according to [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules