### PR TITLE
Bugfix: Rate limiter

### DIFF
--- a/src/Chat/Queue.js
+++ b/src/Chat/Queue.js
@@ -34,12 +34,15 @@ class Queue extends BetterQueue {
 
   incrementRateLimiter(weight) {
     return () => {
-      this.rateLimiter = this.rateLimiter + 1 / weight
+      this.rateLimiter += 1 / weight
     }
   }
 
   burnDownRateLimiter() {
-    this.rateLimiter = Math.max(this.rateLimiter - 1, 0)
+    this.rateLimiter = Math.max(
+      this.rateLimiter - constants.QUEUE_BURNDOWN_RATE,
+      0,
+    )
   }
 
   push({ fn, priority, weight }) {

--- a/src/Chat/constants.js
+++ b/src/Chat/constants.js
@@ -21,11 +21,12 @@ export const COMMAND_TIMEOUT = 1000 // milliseconds.
 export const CLIENT_PRIORITY = 100
 
 // See https://dev.twitch.tv/docs/irc/guide/#command--message-limits.
-export const RATE_LIMIT_USER = 40 // per minute.
-export const RATE_LIMIT_MODERATOR = 200 // per minute.
-export const RATE_LIMIT_KNOWN_BOT = 100 // per minute.
-export const RATE_LIMIT_VERIFIED_BOT = 15000 // per minute.
+export const RATE_LIMIT_USER = 20 // per period.
+export const RATE_LIMIT_MODERATOR = 100 // per period.
+export const RATE_LIMIT_KNOWN_BOT = 50 // per period.
+export const RATE_LIMIT_VERIFIED_BOT = 7500 // per period.
 
+export const QUEUE_BURNDOWN_RATE = 1 / RATE_LIMIT_USER
 export const QUEUE_TICK_RATE = 1000 // milliseconds.
 
 export const ERROR_CONNECT_TIMED_OUT = 'ERROR: connect timed out'


### PR DESCRIPTION
## Proposed changes

The current rate limiting system doesn't work as intended. It should burn down gradually.
The limit is 1 and by subtract 1 per second will make the score going down to 0 whenever the situation, meaning no rate limiting is actually here.

The limits are also wrong because the Twitch period is 30 seconds, not 1 minute.
If a user sends 40 messages in 1 second for example, the IRC server will ban him because of that.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

* [x] I have read the [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] My PR is named according to [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] Lint and unit tests pass locally with my changes
* [x] I have added tests that prove my fix is effective or that my feature works
* [x] I have added necessary documentation (if appropriate)
* [x] Any dependent changes have been merged and published in downstream modules