### PR TITLE
Bugfix: Fix missing index.d.ts file on npm 

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,7 +36,8 @@
     "dist",
     "examples",
     "lib",
-    "src"
+    "src",
+    "index.d.ts"
   ],
   "runkitExampleFilename": "examples/runkit.js",
   "scripts": {


### PR DESCRIPTION
## Proposed changes

Include the `index.d.ts` file when publising the library, this makes TypeScript pick up proper typing for this library when consumed and not give an error complaining about the missing `index.d.ts` file.

## Types of changes

* [x] Bugfix (non-breaking change which fixes an issue)

## Checklist

* [x] I have read the [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [x] My PR is named according to [CONTRIBUTING](https://github.com/twitch-apis/twitch-js/blob/master/CONTRIBUTING.md) doc
* [ ] Lint and unit tests pass locally with my changes
* [ ] I have added tests that prove my fix is effective or that my feature works
* [ ] I have added necessary documentation (if appropriate)
* [ ] Any dependent changes have been merged and published in downstream modules

## Further comments

This change does not affect any code, and only fixes an issue with packaging.
